### PR TITLE
Avoid importing XPCOMUtils/Services into the experiment API as they are already available

### DIFF
--- a/extension/experiments/.eslintrc.js
+++ b/extension/experiments/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
     ExtensionAPI: false,
     ExtensionCommon: false,
     ExtensionUtils: false,
+    Services: false,
     XPCOMUtils: false,
   },
 };

--- a/extension/experiments/remotesettings/api.js
+++ b/extension/experiments/remotesettings/api.js
@@ -1,7 +1,4 @@
-ChromeUtils.import("resource://gre/modules/XPCOMUtils.jsm");
-
 XPCOMUtils.defineLazyModuleGetters(this, {
-  Services: "resource://gre/modules/Services.jsm",
   RemoteSettings: "resource://services-settings/remote-settings.js",
 });
 


### PR DESCRIPTION
Services was added to the [experiment api global scope in FF 88](https://bugzilla.mozilla.org/show_bug.cgi?id=1698158), and XPCOMUtils was available before that.