### PR TITLE
Switch to import the remote-settings ES module directly

### DIFF
--- a/extension/experiments/remotesettings/api.js
+++ b/extension/experiments/remotesettings/api.js
@@ -1,5 +1,5 @@
-XPCOMUtils.defineLazyModuleGetters(this, {
-  RemoteSettings: "resource://services-settings/remote-settings.js",
+ChromeUtils.defineESModuleGetters(this, {
+  RemoteSettings: "resource://services-settings/remote-settings.sys.mjs",
 });
 
 const { EventManager } = ExtensionCommon;


### PR DESCRIPTION
The remote-settings.js was rewritten to an ES module in FF 112. I think we can now move the import to import the ES module directly.