### PR TITLE
Make clearing local data also clear the attachment cache (#191).

### DIFF
--- a/extension/experiments/remotesettings/api.js
+++ b/extension/experiments/remotesettings/api.js
@@ -215,6 +215,7 @@ var remotesettings = class extends ExtensionAPI {
                 await (await client.openCollection()).clear();
               } else {
                 await client.db.clear();
+                await client.attachments.prune([]);
               }
 
               refreshUI();


### PR DESCRIPTION
This calls `attachments.prune()` after clearing the database, which will remove all the attachments as there's no references in the database and so it will think they have all expired.