### PR TITLE
chore: Update update.json for the 1.10.0 release

### DIFF
--- a/update.json
+++ b/update.json
@@ -3,8 +3,8 @@
     "remote-settings-devtools@mozilla.com": {
       "updates": [
         {
-          "version": "1.10.0_TBD",
-          "update_link": "https://github.com/mozilla-extensions/remote-settings-devtools/releases/download/1.10.0-build1/remote-settings-devtools.xpi"
+          "version": "1.10.0buildid20240610.091201",
+          "update_link": "https://github.com/mozilla-extensions/remote-settings-devtools/releases/download/1.10.0-build2/remote-settings-devtools.xpi"
         }
       ]
     }


### PR DESCRIPTION
Updates the update.json so that clients will be able to get the latest version.