### PR TITLE
Add support for using moz-src URIs or falling back to the original resource.

### DIFF
--- a/extension/experiments/remotesettings/api.js
+++ b/extension/experiments/remotesettings/api.js
@@ -1,5 +1,15 @@
-ChromeUtils.defineESModuleGetters(this, {
-  RemoteSettings: "resource://services-settings/remote-settings.sys.mjs",
+// Handle migration from resource to moz-src, see bug 1951644.
+ChromeUtils.defineLazyGetter(this, "RemoteSettings", () => {
+  try {
+    return ChromeUtils.importESModule(
+      "moz-src:///services/settings/remote-settings.sys.mjs",
+    ).RemoteSettings;
+  } catch {
+    // Fallback to URI format prior to FF 143.
+    return ChromeUtils.importESModule(
+      "resource://services-settings/remote-settings.sys.mjs",
+    ).RemoteSettings;
+  }
 });
 
 /* global ExtensionAPI, ExtensionCommon, ExtensionUtils, Services */


### PR DESCRIPTION
This is needed to allow the add-on to continue working post moz-src migration. We're not yet doing the migrations in firefox-main, but we'd like to prepare add-ons and get new releases out, so that there should be no issues when we do the migration.