### PR TITLE
chore: Fix the update version in update.json

### DIFF
--- a/update.json
+++ b/update.json
@@ -3,7 +3,7 @@
     "remote-settings-devtools@mozilla.com": {
       "updates": [
         {
-          "version": "2.0.0",
+          "version": "2.0.20260202.151529",
           "update_link": "https://github.com/mozilla-extensions/remote-settings-devtools/releases/download/v2.0.0/remote-settings-devtools.xpi"
         }
       ]


### PR DESCRIPTION
The add-on won't automatically update at the moment because the version field doesn't match that of the shipped add-on.